### PR TITLE
IME and mouse improvements

### DIFF
--- a/app/src/main/java/org/tfv/deskflow/services/GlobalInputService.kt
+++ b/app/src/main/java/org/tfv/deskflow/services/GlobalInputService.kt
@@ -69,6 +69,7 @@ import org.tfv.deskflow.client.events.KeyboardEvent
 import org.tfv.deskflow.client.events.MouseEvent
 import org.tfv.deskflow.client.events.ScreenEvent
 import org.tfv.deskflow.client.models.ClipboardData
+import org.tfv.deskflow.client.util.Keyboard
 import org.tfv.deskflow.client.util.logging.KLoggingManager
 import org.tfv.deskflow.components.GlobalKeyboardManager
 import org.tfv.deskflow.ext.canDrawOverlays
@@ -471,6 +472,20 @@ class GlobalInputService : AccessibilityService() {
    */
   private fun onKeyboardEvent(event: KeyboardEvent) {
     log.debug { "onKeyboardEvent: $event" }
+
+    // always process modifier key events (both Down and Up) to keep keyboardManager state synchronized
+    val modKey = Keyboard.findModifierKey(event.id.toInt())
+    if (modKey != null) {
+      log.debug { "Modifier key event: $modKey, type=${event.type}" }
+      keyboardManager.process(event)
+      return
+    }
+
+    // Only handle Down and Repeat events for non-modifier keys - ignore Up to avoid duplicates
+    if (event.type == KeyboardEvent.Type.Up) {
+      return
+    }
+
     keyboardManager.process(event)
   }
 

--- a/app/src/main/java/org/tfv/deskflow/services/GlobalInputService.kt
+++ b/app/src/main/java/org/tfv/deskflow/services/GlobalInputService.kt
@@ -255,7 +255,9 @@ class GlobalInputService : AccessibilityService() {
 
     if (kbWasOpen) return
 
-    if (!serviceClient.state.isConnected) return
+    if (!serviceClient.stateFlow.value.isConnected || !serviceClient.stateFlow.value.isEnabled) {
+      return
+    }
 
     keyboardWasOpen.store(true)
 

--- a/app/src/main/java/org/tfv/deskflow/services/VirtualKeyboardService.kt
+++ b/app/src/main/java/org/tfv/deskflow/services/VirtualKeyboardService.kt
@@ -367,6 +367,13 @@ class VirtualKeyboardService : InputMethodService() {
     keyboardViewLifecycleOwner.onPause()
   }
 
+  override fun onComputeInsets(outInsets: Insets?) {
+    super.onComputeInsets(outInsets)
+    if (outInsets != null) {
+      outInsets.contentTopInsets = outInsets.visibleTopInsets
+    }
+  }
+
   override fun onCreateInputView(): View {
     log.debug { "onCreateInputView" }
     val win = window.window ?: return super.onCreateInputView()

--- a/app/src/main/java/org/tfv/deskflow/services/VirtualKeyboardService.kt
+++ b/app/src/main/java/org/tfv/deskflow/services/VirtualKeyboardService.kt
@@ -166,8 +166,9 @@ class VirtualKeyboardService : InputMethodService() {
 
   internal fun saveEditHistory(
     info: EditorInfo?,
-    extractedText: ExtractedText,
+    extractedText: ExtractedText?,
   ) {
+    if (extractedText == null) return
     getEditHistory(info)?.save(extractedText.text.toString(), maxSize = 25)
   }
 
@@ -358,6 +359,7 @@ class VirtualKeyboardService : InputMethodService() {
   }
 
   override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
+    super.onStartInputView(info, restarting)
     keyboardViewLifecycleOwner.onResume()
   }
 
@@ -413,14 +415,14 @@ class VirtualKeyboardService : InputMethodService() {
     return view
   }
 
-  fun currentExtractedTest(): ExtractedText {
+  fun currentExtractedTest(): ExtractedText? {
     return currentInputConnection.getExtractedText(ExtractedTextRequest(), 0)
   }
 
   private fun applyCommand(
     command: String?,
     ic: InputConnection = currentInputConnection,
-    extractedText: ExtractedText =
+    extractedText: ExtractedText? =
       ic.getExtractedText(ExtractedTextRequest(), 0),
   ) {
     command?.let {
@@ -495,6 +497,8 @@ class VirtualKeyboardService : InputMethodService() {
 
     // 5. If all the previous checks passed, grab the current `ExtractedText` of
     // the `InputConnection`.
+    // Note: Some apps (like terminal emulators) return null for getExtractedText,
+    // but commitText still works for basic input.
     val et = ic.getExtractedText(ExtractedTextRequest(), 0)
     val mods = event.getModifiers()
     val editHistory = getEditHistory()

--- a/app/src/main/java/org/tfv/deskflow/ui/components/VirtualKeyboardView.kt
+++ b/app/src/main/java/org/tfv/deskflow/ui/components/VirtualKeyboardView.kt
@@ -36,7 +36,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -47,6 +52,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -106,6 +112,23 @@ fun VirtualKeyboardView(
                     )
                     Spacer(modifier = Modifier.weight(1f))
                     ConnectionStatusLabel(connState)
+
+                    // IME Picker Button
+                    val context = LocalContext.current
+                    IconButton(
+                        onClick = {
+                            // Show IME picker
+                            val imm = context.getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
+                            imm.showInputMethodPicker()
+                        },
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = stringResource(R.string.keyboard_picker_button_desc),
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/res/raw/editor_actions_defaults.json
+++ b/app/src/main/res/raw/editor_actions_defaults.json
@@ -72,5 +72,26 @@
       "Meta+Shift+z",
       "Super+Shift+z"
     ]
+  },
+  {
+    "actionId": 11,
+    "label": "Insert Newline",
+    "defaultShortcutKeys": [
+      "Shift+Return"
+    ]
+  },
+  {
+    "actionId": 12,
+    "label": "Send Control Enter",
+    "defaultShortcutKeys": [
+      "Control+Return"
+    ]
+  },
+  {
+    "actionId": 13,
+    "label": "Handle Return",
+    "defaultShortcutKeys": [
+      "Return"
+    ]
   }
 ]

--- a/app/src/main/res/raw/global_actions_defaults.json
+++ b/app/src/main/res/raw/global_actions_defaults.json
@@ -127,10 +127,8 @@
     "actionId": 20,
     "label": "Dpad Center",
     "defaultShortcutKeys":  [
-      "Control+Return",
       "Meta+Return",
-      "Super+Return",
-      "Return"
+      "Super+Return"
     ],
     "ignoreIME": false
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="permission_dialog_buttons_dismiss">Ignore</string>
     <string name="permission_dialog_nearby_devices_message">Deskflow needs to be able to search for nearby devices on your network.</string>
     <string name="permission_dialog_ime_enabled_message">In order to use Deskflow, you must enable the Deskflow keyboard in settings.</string>
+    <string name="keyboard_picker_button_desc">Switch keyboard</string>
 
 
 </resources>

--- a/client/src/main/java/org/tfv/deskflow/client/util/KeyCodes.kt
+++ b/client/src/main/java/org/tfv/deskflow/client/util/KeyCodes.kt
@@ -35,7 +35,7 @@ object Keyboard {
     Pause(0xEF13),  /* Pause, hold */
     ScrollLock(0xEF14),
     SysReq(0xEF15),
-    Escape(0xEF1B),
+    Escape(0xEF1B, "\u001B"), /* Escape character (ESC) */
     Henkan(0xEF23),           /* Start/Stop Conversion */
     Kana(0xEF26),             /* Kana */
     HiraganaKatakana(0xEF27), /* Hiragana/Katakana toggle */
@@ -51,8 +51,8 @@ object Keyboard {
     Up(0xEF52),    /* Move up, up arrow */
     Right(0xEF53), /* Move right, right arrow */
     Down(0xEF54),  /* Move down, down arrow */
-    PageUp(0xEF55),
-    PageDown(0xEF56),
+    PageUp(0xEF55, "\u001B[5~"), /* Page Up */
+    PageDown(0xEF56, "\u001B[6~"), /* Page Down */
     End(0xEF57),   /* EOL */
     Begin(0xEF58); /* BOL */
 


### PR DESCRIPTION
Hey, thanks for the cool app!

Sorry for the large PR, I started by fixing a couple of issues nagging me, and then ended up doing a bunch of improvements to IME and mouse emulation in general.

This PR does the following (big ticket items at least in my opinion in bold):
- Hides/shows mouse pointer when the client is disconnected, disabled or the cursor has left our screen
- Shows IME picker when deskflow disconnects (after a small delay), so we dont need to go into settings to change it
  - Also adds IME picker button to the IME statusbar for quick access
  - Resets IME tracking on disconnect, so we'll change back to our IME on connect
- **Makes mouse scrolling smoother** (and fixes it at least for me, as there was a check for minimum scoll movement which never happened with my mouse), and also makes the scrolling always happen from cursor location
    - Homescreen special handling is currently disabled (direction of swipe is reversed and swipe is done from center of screen) - might make this a configurable setting later
    - For example settings app on my device is considered to be homescreen and thus scrolling there was also reversed
- Fixes IME working in terminal apps like JuiceSSH, and also adds special handling for control character combinations
  - Also adds imeText for Escape, PageUp/Down, for terminal use (Alt-Escape sends the Escape, as Escape is still global back shortcut)
- Fixes duplicate navigation keys
- Allows key repeat
- Fixes always switching back to deskflow IME even when client manually disabled
- **Adds mouse drag and drop**, with support for long hold drag and simple swiping drag
- Adds separate actions to mouse buttons 2-5
  - Right click is 2-finger touch, middle click is 3-finger touch, both support long hold drag and swipes
  - Side button back is Back shortcut, side forward opens app switcher
- Fixes IME overlapping input fields (happened at least in Discord, in landscape mode)
- Handles Return editor actions so enter works as expected in most input fields
  - Control-Enter sends literal Control-Enter, and works as "send" in for example Discord
- **Support for zoom in/out gesture** with control + mouse scroll wheel

I have further features in my fork's other branches, including:
- **Verifying peer certificate fingerprint** on first connect
- **Client TLS certificate authentication support**
- Option to disconnect when device screen turns off
- Keeping device screen on during mouse/keyboard activity
- Handles device screen rotation
- **Support non-default displays**: for example PC mode on Lenovo tablets, external hdmi monitor
  - Still only supports one display at a time, currently automatically always chooses latest connected display
- Some battery saving optimizations when connection disabled
  - Stopping the connection removes the protocol client completely, so it also works as a way to reset the client if we end up in weird state
- Adds support for media keys (volume up/down, mute, next/prev track and play/pause)
- And bunch of smaller fixes: handshake timeout, reconnect on server busy message, syncing connected status to actual connection state etc

I can push those commits into this PR as well, and to be honest it might be difficult to do large changes to this PR as my later branches are all based on this, and rebasing gets messy quick.